### PR TITLE
docs: add subpath and reporitory_url for oci

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,34 +199,35 @@ The file MUST have the following structure:
 
 Field descriptions:
 
-| Field               | Required | Description                                                                                                                                                 |
-|---------------------|:--------:|-------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| updated_at          |    ✓     | Timestamp indicating when this index.json was last updated.                                                                                                 |
-| packages            |    ✓     | Array of objects, each representing a package in the repository.                                                                                            |
-| packages[].id       |    ✓     | Identifier of the package. Currently, only Package URL (PURL) is accepted. Version and qualifiers MUST be omitted as they are included in the VEX document. |
-| packages[].location |    ✓     | Relative path to the VEX file for this package within the archive. Clients MUST use this field to locate specific package VEX files.                        |
-| packages[].format   |    -     | Format of the VEX data. Either "openvex" or "csaf". If omitted, "openvex" is assumed.                                                                       |
+| Field               | Required | Description                                                                                                                                                                                                                                             |
+|---------------------|:--------:|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| updated_at          |    ✓     | Timestamp indicating when this index.json was last updated.                                                                                                                                                                                             |
+| packages            |    ✓     | Array of objects, each representing a package in the repository.                                                                                                                                                                                        |
+| packages[].id       |    ✓     | Identifier of the package. Currently, only Package URL (PURL) is accepted. Version, qualifiers, and subpath MUST be omitted as they are included in the VEX document. For OCI type packages, the `repository_url` qualifier MUST be included in the id. |
+| packages[].location |    ✓     | Relative path to the VEX file for this package within the archive. Clients MUST use this field to locate specific package VEX files.                                                                                                                    |
+| packages[].format   |    -     | Format of the VEX data. Either "openvex" or "csaf". If omitted, "openvex" is assumed.                                                                                                                                                                   |
 
 The schema for the index file is defined [here](./index.schema.json).
 
 ### 3.3 VEX Documents
 
-Each package's VEX information MUST be stored in a separate JSON file, following the path structure defined in the index.json file. The content of these files MUST adhere to the VEX format specification (OpenVEX or CSAF VEX) as specified in the `format` field. A single VEX document MAY include information for different versions and qualifiers of the same package.
+Each package's VEX information MUST be stored in a separate JSON file, following the path structure defined in the index.json file. The content of these files MUST adhere to the VEX format specification (OpenVEX or CSAF VEX) as specified in the `format` field.
+A single VEX document MAY include information for different versions, qualifiers and subpaths of the same package.
 
 For OpenVEX document examples, please refer to the [OpenVEX specification](https://github.com/openvex/spec/blob/main/OPENVEX-SPEC.md#example).
 
 ### 3.4 Usage Notes
 
 #### Directory Structure
-- It is RECOMMENDED to create directory structures for packages based on their PURL, excluding version and qualifiers. For example, a package with PURL "pkg:deb/debian/curl" could be stored in "pkg/deb/debian/curl/vex.json".
+- It is RECOMMENDED to create directory structures for packages based on their PURL, excluding version, qualifiers and subpath. For example, a package with PURL "pkg:deb/debian/curl" could be stored in "pkg/deb/debian/curl/vex.json".
 - For OCI packages, the `repository_url` qualifier of the PURL MAY be used to create the directory structure. For example, a package with PURL "pkg:oci/debian@sha256:3e45770a143ee5afd1ebde5a6aea6e32a71d2bt5602f5dac8025db0d9cc19f10?repository_url=docker.io/library/debian" could be stored in "pkg/oci/docker.io/library/debian/vex.json".
 - The actual location of VEX files MAY be freely defined in the index.json file's `location` field, regardless of the recommended structure.
 - All file paths within the archive MUST use forward slashes (/) as separators, regardless of the operating system.
 - Package names in the directory structure MUST be URL-encoded if they contain special characters.
 
 #### VEX Document Content
-- A single VEX document MAY include information for different versions and qualifiers of the same package.
-- When querying for a specific version or qualifier, clients MUST parse the entire VEX document to find the relevant information.
+- A single VEX document MAY include information for different versions, qualifiers and subpaths of the same package.
+- When querying for a specific version, qualifier or subpath, clients MUST parse the entire VEX document to find the relevant information.
 
 ### 3.5 Updating the Repository
 

--- a/index.schema.json
+++ b/index.schema.json
@@ -14,13 +14,13 @@
         "properties": {
           "id": {
             "type": "string",
-            "pattern": "^pkg:[a-zA-Z+.-]+(/[a-zA-Z+.-]+)(/[^@]+)$",
-            "description": "Package URL (PURL) of the package, excluding version and qualifiers"
+            "pattern": "^pkg:[a-zA-Z+.-]+(/[a-zA-Z+.-]+)(/[^@]+)(\\?repository_url=[a-zA-Z0-9_/.-:]+)?$",
+            "description": "Package URL (PURL) of the package, excluding version, qualifiers, and subpath. For OCI type, repository_url qualifier must be included."
           },
           "location": {
             "type": "string",
             "pattern": "^[a-zA-Z0-9_/.-]+\\.json$",
-            "description": "Relative path to the VEX file for this package within the tar.gz archive"
+            "description": "Relative path to the VEX file for this package within the archive"
           },
           "format": {
             "type": "string",


### PR DESCRIPTION
## Description
This PR includes two changes:

- Add subpath exclusion in index.json
- Add special requirements for OCI package types

## Key changes:

- Updated the description of packages[].id in index.json to explicitly mention that subpath should be omitted along with version and qualifiers.
- Added a requirement for OCI package types to include the `repository_url` qualifier in their id.
- Updated the JSON Schema for index.json to reflect these changes:
    - Modified the pattern for the id field to allow for the repository_url qualifier.
    - Updated the description of the id field to mention the special case for OCI packages.
